### PR TITLE
Добавлена возможность не указывать номенклатуру товаров при передачи данных чека с сайта в кассу

### DIFF
--- a/lang/ru/lib/cashboxmodul.php
+++ b/lang/ru/lib/cashboxmodul.php
@@ -1,3 +1,4 @@
 <?php
   $MESS['CASHBOX_MODULPOS_NAME'] = 'МодульКасса';
+  $MESS['CASHBOX_FAKE_PRODUCT_NAME'] = 'Продажа по свободной цене';
 ?>

--- a/lang/ru/options.php
+++ b/lang/ru/options.php
@@ -22,5 +22,7 @@ $MESS['REFERENCES_VAT_0'] = "НДС 0%";
 $MESS['REFERENCES_VAT_EXAMPT'] = "НДС не облагается";
 $MESS['REFERENCES_VAT_18_118'] = "НДС с рассч. ставкой 18%";
 $MESS['REFERENCES_VAT_10_110'] = "НДС с рассч. ставкой 10%";
+$MESS['MODULPOS_DO_NOT_SEND_INVENT_POSITIONS'] = "Не передавать номенлатуру товаров в чеке";
+$MESS['MODULPOS_DO_NOT_SEND_INVENT_POSITIONS_DESCRIPTION'] = "Наименование товаров (работ и услуг) и их количество индивидуальные предприниматели на ПСН, УСН, ЕСХН или ЕНВД (кроме торгующих подакцизными товарами), могут не указывать до 01.02.2021 (<a href='http://www.consultant.ru/document/cons_doc_LAW_200743/6a73a7e61adc45fc3dd224c0e7194a1392c8b071/' target='_blank'>п. 17 ст. 7 Закона № 290-ФЗ</a>)";
 
 ?>

--- a/lib/cashboxmodul.php
+++ b/lib/cashboxmodul.php
@@ -151,7 +151,7 @@ class CashboxModul extends Cashbox {
         }
     }
 
-    private static function getAssociationData() {
+    public static function getAssociationData() {
         $associated_login =  Option::get(MODULE_CASHBOX_NAME, 'associated_login', '#empty#');
         $associated_password = Option::get(MODULE_CASHBOX_NAME, 'associated_password', '');
         if ($associated_login == '#empty#') {

--- a/lib/cashboxmodul.php
+++ b/lib/cashboxmodul.php
@@ -168,6 +168,9 @@ class CashboxModul extends Cashbox {
         return Loc::getMessage('CASHBOX_MODULPOS_NAME');
     }
 
+    /**
+     * @param \Bitrix\Sale\Cashbox\SellCheck $check
+     */
     public static function enqueCheck($check) {
         static::log('enqueueCheck called!'.var_export($check->getDataForCheck(), TRUE));
         $document = static::createDocuemntByCheck($check->getDataForCheck());
@@ -199,10 +202,15 @@ class CashboxModul extends Cashbox {
 		        );
 		
 		$inventPositions = array();
-		foreach ($checkData['items'] as $item) {
-			$inventPositions[] = static::createItemPositionByCheckItem($item);
-		}
-		$document['inventPositions'] = $inventPositions;
+
+		if(Option::get(MODULE_CASHBOX_NAME, "default_do_not_send_invent_positions", false)) {
+            $inventPositions[] = static::createFakeItemPosition($checkData['items']);
+        } else {
+            foreach ($checkData['items'] as $item) {
+                $inventPositions[] = static::createItemPositionByCheckItem($item);
+            }
+        }
+        $document['inventPositions'] = $inventPositions;
 		
 		$moneyPositions = array();
 		foreach ($checkData['payments'] as $paymentItem) {
@@ -295,7 +303,41 @@ class CashboxModul extends Cashbox {
         $port = in_array($port, array(80, 443)) ? '' : ':'.$port;
         $token = static::createValidationToken($document_number);
         return sprintf('%s://%s%s/bitrix/tools/%s?token=%s', $scheme, $domain, $port, $handler_file, $token);
-    }    
+    }
+
+    /**
+     * Метод подставляет фиктивное значение номенклатуры товаров,
+     * согласно п. 17 ст. 7 Закона № 290-ФЗ
+     *
+     * @see http://www.consultant.ru/document/cons_doc_LAW_200743/6a73a7e61adc45fc3dd224c0e7194a1392c8b071/
+     *
+     * @param $items
+     *
+     * @return array
+     */
+    private static function createFakeItemPosition($items)
+    {
+        $itemName = Loc::getMessage('CASHBOX_FAKE_PRODUCT_NAME');
+        if (SITE_CHARSET == 'windows-1251') {
+            $itemName = mb_convert_encoding($itemName, "utf-8", "windows-1251");
+        }
+
+        $vatTag = Option::get(MODULE_CASHBOX_NAME, "default_vat_tag", '1105');
+
+        $totalSum = 0;
+        foreach ($items as $item){
+            $totalSum = $totalSum + static::createPriceByCheckItem($item);
+        }
+
+        return array(
+            'description' => '',
+            'name' => $itemName,
+            'price' => $totalSum,
+            'quantity' => 1,
+            'vatTag' => intval($vatTag),
+            'discSum' => 0
+        );
+    }
 
     public function buildCheckQuery(Check $check) {
         return array();

--- a/options.php
+++ b/options.php
@@ -58,8 +58,9 @@ if ((!empty($save) || !empty($restore)) && $request->isPost() && check_bitrix_se
         CAdminMessage::showMessage(Loc::getMessage("REFERENCES_INVALID_VALUE"));
       }
     }
-    if ($request->getPost('default_vat_tag')) {
+    if ($request->getPost('default_vat_tag') && $request->getPost('default_do_not_send_invent_positions')) {
         Option::set(MODULE_CASHBOX_NAME, 'default_vat_tag', $request->getPost('default_vat_tag'));
+        Option::set(MODULE_CASHBOX_NAME, 'default_do_not_send_invent_positions', $request->getPost('default_do_not_send_invent_positions'));
         CAdminMessage::showMessage(array("MESSAGE" => "Настройки успешно сохранены","TYPE" => "OK"));
     }
   }
@@ -154,6 +155,23 @@ $tabControl->begin();
                 <option value="1106" <?=($defaultVatTag == '1106'?'selected':'')?> ><?=Loc::getMessage("REFERENCES_VAT_18_118")?></option>
                 <option value="1107" <?=($defaultVatTag == '1107'?'selected':'')?> ><?=Loc::getMessage("REFERENCES_VAT_10_110")?></option>
             </select>
+        </td>
+    </tr>
+    <tr>
+        <td width="40%">
+            <label for="default_do_not_send_invent_positions"><?=Loc::getMessage("MODULPOS_DO_NOT_SEND_INVENT_POSITIONS") ?></label>:
+            <br>
+            <?=Loc::getMessage("MODULPOS_DO_NOT_SEND_INVENT_POSITIONS_DESCRIPTION") ?>
+        </td>
+        <td width="60%">
+            <input type="hidden" name="default_do_not_send_invent_positions" value="0"/>
+            <input
+                    type="checkbox"
+                    id="default_do_not_send_invent_positions"
+                    name="default_do_not_send_invent_positions"
+                    value="1"
+                <?=(Option::get(MODULE_CASHBOX_NAME, "default_do_not_send_invent_positions", false) == true ? 'checked' : '');?>
+            />
         </td>
     </tr>
 


### PR DESCRIPTION
Наименование товаров (работ и услуг) и их количество индивидуальные предприниматели на ПСН, УСН, ЕСХН или ЕНВД (кроме торгующих подакцизными товарами), **могут не указывать до 01.02.2021** (п. 17 ст. 7 Закона № 290-ФЗ)